### PR TITLE
Added feature to delete image from Blogpost issue#662

### DIFF
--- a/routes/post.router.js
+++ b/routes/post.router.js
@@ -363,6 +363,26 @@ router.post('/posts/:postId/delete', auth, async (req, res) => {
 		});
 });
 
+// delete post image route
+router.delete('/posts/:postId/image', auth, async (req, res) => {
+	try {
+		const { user } = req;
+		if (!user) {
+			return res.status(401).redirect('/log-in');
+		}
+		const post = await Blog.findById(req.params.postId);
+		if (post.author.toString() !== user._id.toString()) {
+			return res.render('404', { isAuthenticated: !!req.user });
+		}
+
+		post.photo = '';
+		await post.save();
+		res.redirect(`/posts/${req.params.postId}`);
+	} catch (e) {
+		return res.render('404', { isAuthenticated: !!req.user });
+	}
+});
+
 router.post('/category', auth, async (req, res) => {
 	const { category } = req.body;
 	if (!category) {

--- a/views/postitems/post.ejs
+++ b/views/postitems/post.ejs
@@ -16,7 +16,27 @@
                 <!-- If there is an image attached with the post then only render the image -->
                 <% if(photo){ %>
                     <img src="..\<%- photo %>" alt="Image attached with the post" class="img-fluid pb-2" id="blog-image">
+                    <% if(isAuthor){ %>
+                        <button type="button" class="btn btn-danger btn-sm float-end" data-bs-toggle="modal" data-bs-target="#exampleModal"><i class="far fa-trash-alt"></i></button>
+                    <% } %>
                 <% } %>
+                <!-- Modal -->
+                <div class="modal fade" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h5 class="modal-title" id="exampleModalLabel">Are you sure you want to delete the image from the post?</h5>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">NO</button>
+                                <form action="/posts/<%= id %>/image?_method=DELETE" method="POST">
+                                    <button type="submit" class="btn btn-primary">YES</button>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div>
                 <%- content %>
                 <!-- If this user is the author then only render the delete button-->
                 <% if(isAuthor){ %>


### PR DESCRIPTION
## What is the change?
Added a button similar to profile image delete button on post page, it will be shown only when there is an image with the post

## Related issue?
close: #662 


## How was it tested?
Tested locally

## Checklist:
Before you create this PR, confirm all the requirements listed below by checking the checkboxes `[x]`:

- [x] Have you followed the [Contribution Guidelines](https://github.com/ALPHAVIO/BlogSite/blob/master/CONTRIBUTING.md) while contributing.
- [x] Have you checked there aren't other open [Pull Requests](https://github.com/ALPHAVIO/BlogSite/pulls) for the same update/change?
- [x] Did you lint your code before making the Pull Request?
- [] Have you made corresponding changes to the documentation?
- [x] Your submission doesn't break any existing feature.
- [x] Have you tested the code before submission?

## Screenshots or Video:
Add a screenshot or demo video if appropriate.

https://user-images.githubusercontent.com/68139755/119665657-3b837a00-be52-11eb-961b-a8cc1535f7c0.mp4

