### PR TITLE
Bug in profile image sizing

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1026,7 +1026,9 @@ input[name='perPage'] {
 /* Profile Image Style */
 
 .profile-img {
-	height: 20vh;
+	width: 220px;
+        height: 220px;
+        object-fit: cover;
 	margin: 2% auto 3% auto;
 	border-radius: 50%;
 	box-shadow: rgba(50, 50, 93, 0.25) 0px 13px 27px -5px,


### PR DESCRIPTION
## What is the change?
Now profile image can see same size in responsive


## Related issue?
close: #990 



## Checklist:
Before you create this PR, confirm all the requirements listed below by checking the checkboxes `[x]`:

- [x] Have you followed the [Contribution Guidelines](https://github.com/ALPHAVIO/BlogSite/blob/master/CONTRIBUTING.md) while contributing.
- [x] Have you checked there aren't other open [Pull Requests](https://github.com/ALPHAVIO/BlogSite/pulls) for the same update/change?
- [] Did you lint your code before making the Pull Request?
- [] Have you made corresponding changes to the documentation?
- [] Your submission doesn't break any existing feature.
- [] Have you tested the code before submission?

## Screenshots or Video:
![n3](https://user-images.githubusercontent.com/52104082/122749228-b782ad80-d2aa-11eb-9547-fbf65c57e8c2.png)![n2](https://user-images.githubusercontent.com/52104082/122749664-3841a980-d2ab-11eb-95ea-0be2e16bebde.png)

