### PR TITLE
FIx Size of delete button in Firefox

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1034,7 +1034,7 @@ input[name='perPage'] {
 }
 
 .delete-img-btn {
-	height: fit-content;
+	height: 40px;
 	margin-left: -2.5em;
 	z-index: 1;
 }


### PR DESCRIPTION
## What is the change?
Size of delete button in Firefox

## Related issue?
close: #1023 

## Checklist:
Before you create this PR, confirm all the requirements listed below by checking the checkboxes `[x]`:

- [x] Have you followed the [Contribution Guidelines](https://github.com/ALPHAVIO/BlogSite/blob/master/CONTRIBUTING.md) while contributing.
- [x] Have you checked there aren't other open [Pull Requests](https://github.com/ALPHAVIO/BlogSite/pulls) for the same update/change?
- [] Did you lint your code before making the Pull Request?
- [] Have you made corresponding changes to the documentation?
- [] Your submission doesn't break any existing feature.
- [] Have you tested the code before submission?

## Screenshots or Video:
![5](https://user-images.githubusercontent.com/52104082/122797090-bb2f2800-d2dc-11eb-9630-0f9666a3cefb.png)
